### PR TITLE
refactor(app): 状態遷移ロジックを AppState にカプセル化する

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ pub enum PlayerState {
 pub struct AppState {
     pub tracks: Vec<TrackInfo>,
     pub selected: usize,
-    pub player_state: PlayerState,
+    player_state: PlayerState,
     /// 直近の再生エラーメッセージ。次の操作で自動クリアされる。
     pub last_error: Option<String>,
 }
@@ -38,5 +38,21 @@ impl AppState {
 
     pub fn current(&self) -> Option<&TrackInfo> {
         self.tracks.get(self.selected)
+    }
+
+    pub fn player_state(&self) -> &PlayerState {
+        &self.player_state
+    }
+
+    pub fn set_playing(&mut self) {
+        self.player_state = PlayerState::Playing;
+    }
+
+    pub fn set_paused(&mut self) {
+        self.player_state = PlayerState::Paused;
+    }
+
+    pub fn set_stopped(&mut self) {
+        self.player_state = PlayerState::Stopped;
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -81,7 +81,7 @@ fn event_loop<B: ratatui::backend::Backend>(
                     if let Some(track) = state.current() {
                         let path = track.path.clone();
                         match player.load_and_play(&path) {
-                            Ok(_) => state.player_state = PlayerState::Playing,
+                            Ok(_) => state.set_playing(),
                             Err(e) => state.last_error = Some(e.to_string()),
                         }
                     }
@@ -89,11 +89,11 @@ fn event_loop<B: ratatui::backend::Backend>(
                 KeyCode::Char(' ') => {
                     state.last_error = None;
                     player.toggle_pause();
-                    state.player_state = if player.is_paused() {
-                        PlayerState::Paused
+                    if player.is_paused() {
+                        state.set_paused();
                     } else {
-                        PlayerState::Playing
-                    };
+                        state.set_playing();
+                    }
                 }
                 KeyCode::Char('n') => {
                     state.last_error = None;
@@ -102,7 +102,7 @@ fn event_loop<B: ratatui::backend::Backend>(
                     if let Some(track) = state.current() {
                         let path = track.path.clone();
                         match player.load_and_play(&path) {
-                            Ok(_) => state.player_state = PlayerState::Playing,
+                            Ok(_) => state.set_playing(),
                             Err(e) => state.last_error = Some(e.to_string()),
                         }
                     }
@@ -114,7 +114,7 @@ fn event_loop<B: ratatui::backend::Backend>(
                     if let Some(track) = state.current() {
                         let path = track.path.clone();
                         match player.load_and_play(&path) {
-                            Ok(_) => state.player_state = PlayerState::Playing,
+                            Ok(_) => state.set_playing(),
                             Err(e) => state.last_error = Some(e.to_string()),
                         }
                     }
@@ -124,8 +124,8 @@ fn event_loop<B: ratatui::backend::Backend>(
         }
 
         // 再生終了を検知して状態を更新
-        if matches!(state.player_state, PlayerState::Playing) && player.is_empty() {
-            state.player_state = PlayerState::Stopped;
+        if matches!(state.player_state(), PlayerState::Playing) && player.is_empty() {
+            state.set_stopped();
         }
     }
 
@@ -182,7 +182,7 @@ fn draw(f: &mut ratatui::Frame, state: &AppState, list_state: &mut ListState) {
     let (status_text, status_color) = if let Some(ref err) = state.last_error {
         (format!(" ⚠ {err}"), Color::Red)
     } else if let Some(track) = state.current() {
-        let status = match state.player_state {
+        let status = match state.player_state() {
             PlayerState::Playing => "▶",
             PlayerState::Paused => "⏸",
             PlayerState::Stopped => "■",


### PR DESCRIPTION
## 概要
- `player_state` フィールドを `pub` から非公開に変更
- `set_playing()` / `set_paused()` / `set_stopped()` の遷移メソッドを追加
- `player_state()` アクセサを追加
- `ui/tui.rs` 内の直接代入をすべて新メソッド呼び出しに置き換え

## テスト計画
- [ ] `cargo build` が通ること
- [ ] `cargo test` が通ること
- [ ] TUI で再生・一時停止・停止の状態表示が正常に動作すること

Closes #7