### PR TITLE
perf(scanner): 拡張子比較で不要なアロケーションを排除する

### DIFF
--- a/src/library/scanner.rs
+++ b/src/library/scanner.rs
@@ -14,7 +14,7 @@ pub fn scan_directory(dir: &Path) -> Result<Vec<PathBuf>, AppError> {
             e.path()
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map(|ext| supported.contains(&ext.to_lowercase().as_str()))
+                .map(|ext| supported.iter().any(|s| ext.eq_ignore_ascii_case(s)))
                 .unwrap_or(false)
         })
         .map(|e| e.path().to_owned())


### PR DESCRIPTION
## 概要
- `ext.to_lowercase().as_str()` はファイルごとに `String` をヒープアロケートしていた
- `eq_ignore_ascii_case()` に変更することでアロケーションなしに大文字小文字を無視した比較が可能

## テスト計画
- [ ] `cargo build` が通ること
- [ ] `cargo test` が通ること
- [ ] `.MP3` / `.FLAC` のような大文字拡張子のファイルも正しくスキャンされること

Closes #9