### PR TITLE
fix: optimize extension comparison to avoid string allocation (closes #9)

### DIFF
--- a/src/library/scanner.rs
+++ b/src/library/scanner.rs
@@ -14,7 +14,7 @@ pub fn scan_directory(dir: &Path) -> Result<Vec<PathBuf>, AppError> {
             e.path()
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map(|ext| supported.contains(&ext.to_lowercase().as_str()))
+                .map(|ext| supported.iter().any(|&s| ext.eq_ignore_ascii_case(s)))
                 .unwrap_or(false)
         })
         .map(|e| e.path().to_owned())


### PR DESCRIPTION
This PR optimizes extension comparison by replacing `to_lowercase()` with `eq_ignore_ascii_case`, thus avoiding an unnecessary string allocation during directory scans.