### PR TITLE
feat: Now Playing ペインに再生経過時間 / 合計時間を表示

### DIFF
--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -52,4 +52,8 @@ impl Player {
     pub fn stop(&self) {
         self.sink.stop();
     }
+
+    pub fn get_pos(&self) -> std::time::Duration {
+        self.sink.get_pos()
+    }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -58,7 +58,7 @@ fn event_loop<B: ratatui::backend::Backend>(
     list_state.select(Some(state.selected));
 
     loop {
-        terminal.draw(|f| draw(f, state, &mut list_state))?;
+        terminal.draw(|f| draw(f, state, player, &mut list_state))?;
 
         if event::poll(std::time::Duration::from_millis(200))?
             && let Event::Key(key) = event::read()?
@@ -125,7 +125,7 @@ fn play_current(state: &mut AppState, player: &Player) {
     }
 }
 
-fn draw(f: &mut ratatui::Frame, state: &AppState, list_state: &mut ListState) {
+fn draw(f: &mut ratatui::Frame, state: &AppState, player: &Player, list_state: &mut ListState) {
     // 3分割レイアウト: トラックリスト / 再生情報 / キーバインド
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -195,8 +195,18 @@ fn draw(f: &mut ratatui::Frame, state: &AppState, list_state: &mut ListState) {
             PlayerState::Paused => "⏸",
             PlayerState::Stopped => "■",
         };
+        let pos = player.get_pos();
+        let elapsed = format!("{}:{:02}", pos.as_secs() / 60, pos.as_secs() % 60);
+        let total = format!(
+            "{}:{:02}",
+            track.duration_secs / 60,
+            track.duration_secs % 60
+        );
         (
-            format!(" {} {} — {}", status, track.title, track.artist),
+            format!(
+                " {} {} — {}  [{} / {}]",
+                status, track.title, track.artist, elapsed, total
+            ),
             Color::Yellow,
         )
     } else {


### PR DESCRIPTION
## 概要

Now Playing ペインに現在の再生位置と合計時間を表示する。

## 変更内容

- `Player::get_pos()` を追加（`rodio 0.19` の `Sink::get_pos()` をラップ）
- `draw()` に `&Player` を渡すよう変更
- Now Playing 表示を `▶ タイトル — アーティスト  [1:23 / 3:57]` 形式に変更

## 表示例

```
▶ King Gnu - AIZO  [1:23 / 3:57]
```

停止中・ポーズ中も経過時間は表示される（`Sink::get_pos()` は最後の位置を保持）。

closes #24