### PR TITLE
test: ratatui TestBackend を使った TUI ユニットテストを追加する

### DIFF
--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -1416,4 +1416,134 @@ mod tests {
             );
         }
     }
+
+    // ── filter_tracks ──────────────────────────────────────────────
+
+    fn make_track(title: &str, artist: &str) -> crate::models::TrackInfo {
+        crate::models::TrackInfo {
+            path: std::path::PathBuf::from("/dummy"),
+            title: title.to_string(),
+            artist: artist.to_string(),
+            album: String::new(),
+            duration_secs: 0,
+        }
+    }
+
+    #[test]
+    fn filter_tracks_empty_query_returns_all() {
+        let tracks = vec![make_track("Song A", "Artist 1"), make_track("Song B", "Artist 2")];
+        assert_eq!(filter_tracks(&tracks, ""), vec![0, 1]);
+    }
+
+    #[test]
+    fn filter_tracks_matches_title_case_insensitive() {
+        let tracks = vec![make_track("Rock Anthem", "Band"), make_track("Jazz Night", "Trio")];
+        assert_eq!(filter_tracks(&tracks, "rock"), vec![0]);
+        assert_eq!(filter_tracks(&tracks, "JAZZ"), vec![1]);
+    }
+
+    #[test]
+    fn filter_tracks_matches_artist() {
+        let tracks = vec![make_track("Title", "The Beatles"), make_track("Title", "Rolling Stones")];
+        assert_eq!(filter_tracks(&tracks, "beatles"), vec![0]);
+        assert_eq!(filter_tracks(&tracks, "stones"), vec![1]);
+    }
+
+    #[test]
+    fn filter_tracks_no_match_returns_empty() {
+        let tracks = vec![make_track("Song", "Artist")];
+        assert_eq!(filter_tracks(&tracks, "zzz"), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn filter_tracks_matches_both_title_and_artist() {
+        let tracks = vec![
+            make_track("Love Song", "Artist"),
+            make_track("Title", "Love Band"),
+            make_track("Other", "Other"),
+        ];
+        assert_eq!(filter_tracks(&tracks, "love"), vec![0, 1]);
+    }
+
+    // ── TestBackend 描画テスト ──────────────────────────────────────
+
+    fn make_terminal(width: u16, height: u16) -> ratatui::Terminal<ratatui::backend::TestBackend> {
+        ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap()
+    }
+
+    #[test]
+    fn draw_source_picker_no_panic() {
+        let mut terminal = make_terminal(80, 24);
+        let entries = vec![
+            SourceEntry::Directory(std::path::PathBuf::from("/music")),
+            SourceEntry::RecentDir(std::path::PathBuf::from("/recent")),
+            SourceEntry::Playlist {
+                path: std::path::PathBuf::from("/playlists/test.json"),
+                name: "test".to_string(),
+            },
+        ];
+        terminal.draw(|f| draw_source_picker(f, &entries, 0)).unwrap();
+    }
+
+    #[test]
+    fn draw_source_picker_shows_entry_labels() {
+        let mut terminal = make_terminal(80, 24);
+        let entries = vec![
+            SourceEntry::Directory(std::path::PathBuf::from("/music")),
+            SourceEntry::Playlist {
+                path: std::path::PathBuf::from("/p.json"),
+                name: "MyList".to_string(),
+            },
+        ];
+        terminal.draw(|f| draw_source_picker(f, &entries, 0)).unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(content.contains("[Dir]"), "content should contain [Dir]");
+        assert!(content.contains("MyList"), "content should contain playlist name");
+    }
+
+    #[test]
+    fn draw_name_input_no_panic() {
+        let mut terminal = make_terminal(80, 24);
+        terminal.draw(|f| draw_name_input(f, "my playlist")).unwrap();
+    }
+
+    #[test]
+    fn draw_name_input_shows_prompt() {
+        let mut terminal = make_terminal(80, 24);
+        terminal.draw(|f| draw_name_input(f, "rock")).unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(content.contains("rock"), "input buffer should be visible");
+    }
+
+    #[test]
+    fn draw_help_overlay_no_panic() {
+        let mut terminal = make_terminal(80, 24);
+        terminal.draw(|f| draw_help_overlay(f, 0)).unwrap();
+    }
+
+    #[test]
+    fn draw_help_overlay_scrolled_no_panic() {
+        let mut terminal = make_terminal(80, 24);
+        // 末尾を超えるオフセットを渡してもパニックしないこと
+        terminal.draw(|f| draw_help_overlay(f, 999)).unwrap();
+    }
+
+    #[test]
+    fn draw_help_overlay_small_terminal_no_panic() {
+        // 極端に小さいターミナルでもパニックしないこと
+        let mut terminal = make_terminal(20, 8);
+        terminal.draw(|f| draw_help_overlay(f, 0)).unwrap();
+    }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -1452,7 +1452,7 @@ mod tests {
     #[test]
     fn filter_tracks_no_match_returns_empty() {
         let tracks = vec![make_track("Song", "Artist")];
-        assert_eq!(filter_tracks(&tracks, "zzz"), Vec::<usize>::new());
+        assert!(filter_tracks(&tracks, "zzz").is_empty());
     }
 
     #[test]
@@ -1490,6 +1490,7 @@ mod tests {
         let mut terminal = make_terminal(80, 24);
         let entries = vec![
             SourceEntry::Directory(std::path::PathBuf::from("/music")),
+            SourceEntry::RecentDir(std::path::PathBuf::from("/recent")),
             SourceEntry::Playlist {
                 path: std::path::PathBuf::from("/p.json"),
                 name: "MyList".to_string(),
@@ -1504,7 +1505,15 @@ mod tests {
             .map(|c| c.symbol())
             .collect();
         assert!(content.contains("[Dir]"), "content should contain [Dir]");
+        assert!(content.contains("[Recent]"), "content should contain [Recent]");
+        assert!(content.contains("[PL]"), "content should contain [PL]");
         assert!(content.contains("MyList"), "content should contain playlist name");
+    }
+
+    #[test]
+    fn draw_source_picker_empty_entries_no_panic() {
+        let mut terminal = make_terminal(80, 24);
+        terminal.draw(|f| draw_source_picker(f, &[], 0)).unwrap();
     }
 
     #[test]
@@ -1528,9 +1537,20 @@ mod tests {
     }
 
     #[test]
-    fn draw_help_overlay_no_panic() {
+    fn draw_help_overlay_shows_keybinds() {
         let mut terminal = make_terminal(80, 24);
         terminal.draw(|f| draw_help_overlay(f, 0)).unwrap();
+        let content: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(content.contains("Enter"), "help should show Enter key");
+        assert!(content.contains("Space"), "help should show Space key");
+        // CJK 文字はバッファ上で1セルずつ分割されるため個別に確認する
+        assert!(content.contains("通"), "help should show Normal section header");
     }
 
     #[test]

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -1431,20 +1431,29 @@ mod tests {
 
     #[test]
     fn filter_tracks_empty_query_returns_all() {
-        let tracks = vec![make_track("Song A", "Artist 1"), make_track("Song B", "Artist 2")];
+        let tracks = vec![
+            make_track("Song A", "Artist 1"),
+            make_track("Song B", "Artist 2"),
+        ];
         assert_eq!(filter_tracks(&tracks, ""), vec![0, 1]);
     }
 
     #[test]
     fn filter_tracks_matches_title_case_insensitive() {
-        let tracks = vec![make_track("Rock Anthem", "Band"), make_track("Jazz Night", "Trio")];
+        let tracks = vec![
+            make_track("Rock Anthem", "Band"),
+            make_track("Jazz Night", "Trio"),
+        ];
         assert_eq!(filter_tracks(&tracks, "rock"), vec![0]);
         assert_eq!(filter_tracks(&tracks, "JAZZ"), vec![1]);
     }
 
     #[test]
     fn filter_tracks_matches_artist() {
-        let tracks = vec![make_track("Title", "The Beatles"), make_track("Title", "Rolling Stones")];
+        let tracks = vec![
+            make_track("Title", "The Beatles"),
+            make_track("Title", "Rolling Stones"),
+        ];
         assert_eq!(filter_tracks(&tracks, "beatles"), vec![0]);
         assert_eq!(filter_tracks(&tracks, "stones"), vec![1]);
     }
@@ -1482,7 +1491,9 @@ mod tests {
                 name: "test".to_string(),
             },
         ];
-        terminal.draw(|f| draw_source_picker(f, &entries, 0)).unwrap();
+        terminal
+            .draw(|f| draw_source_picker(f, &entries, 0))
+            .unwrap();
     }
 
     #[test]
@@ -1496,7 +1507,9 @@ mod tests {
                 name: "MyList".to_string(),
             },
         ];
-        terminal.draw(|f| draw_source_picker(f, &entries, 0)).unwrap();
+        terminal
+            .draw(|f| draw_source_picker(f, &entries, 0))
+            .unwrap();
         let content: String = terminal
             .backend()
             .buffer()
@@ -1505,9 +1518,15 @@ mod tests {
             .map(|c| c.symbol())
             .collect();
         assert!(content.contains("[Dir]"), "content should contain [Dir]");
-        assert!(content.contains("[Recent]"), "content should contain [Recent]");
+        assert!(
+            content.contains("[Recent]"),
+            "content should contain [Recent]"
+        );
         assert!(content.contains("[PL]"), "content should contain [PL]");
-        assert!(content.contains("MyList"), "content should contain playlist name");
+        assert!(
+            content.contains("MyList"),
+            "content should contain playlist name"
+        );
     }
 
     #[test]
@@ -1519,7 +1538,9 @@ mod tests {
     #[test]
     fn draw_name_input_no_panic() {
         let mut terminal = make_terminal(80, 24);
-        terminal.draw(|f| draw_name_input(f, "my playlist")).unwrap();
+        terminal
+            .draw(|f| draw_name_input(f, "my playlist"))
+            .unwrap();
     }
 
     #[test]
@@ -1550,7 +1571,10 @@ mod tests {
         assert!(content.contains("Enter"), "help should show Enter key");
         assert!(content.contains("Space"), "help should show Space key");
         // CJK 文字はバッファ上で1セルずつ分割されるため個別に確認する
-        assert!(content.contains("通"), "help should show Normal section header");
+        assert!(
+            content.contains("通"),
+            "help should show Normal section header"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`ratatui::backend::TestBackend` を使ったオフスクリーン描画テストと、純粋関数 `filter_tracks` のユニットテストを追加した。手動テストに頼っていた描画ロジックのリグレッションを自動検出できるようになる。

## 変更内容

### filter_tracks テスト（純粋関数）
- 空クエリで全インデックスを返すこと
- タイトルの大文字小文字を無視してマッチすること
- アーティスト名にマッチすること
- マッチなしで空リストを返すこと
- タイトル・アーティスト両方を横断してマッチすること

### TestBackend 描画テスト
- `draw_source_picker`: パニックなし・`[Dir]`/`[Recent]`/`[PL]` ラベルが描画されること・空エントリでもパニックなし
- `draw_name_input`: パニックなし・入力バッファが描画されること
- `draw_help_overlay`: キーバインド内容が描画されること・大きいスクロールオフセットでもパニックなし・小サイズ端末でもパニックなし

## 設計上の注意

`draw()` 本体のテストは `Player::new()` が実際の音声デバイスを要求するため今回は対象外とした。テスト可能な範囲として、`Player` に依存しないオーバーレイ描画関数と純粋関数に絞っている。

## レビュー指摘への対応

- `Vec::<usize>::new()` → `assert!(result.is_empty())` に変更（慣用的な書き方）
- `draw_source_picker` のラベル検証に `[Recent]`/`[PL]` を追加
- 空エントリリストのエッジケーステストを追加
- ヘルプオーバーレイのコンテンツ検証を追加（`Enter`/`Space`/CJK 文字）
- CJK 文字はバッファ上で 1 セルずつ格納されるため、連結文字列ではなく単一文字で検証

Closes #55