### PR TITLE
fix: ライト/ダーク両テーマに対応したアダプティブカラーに修正

### DIFF
--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -944,7 +944,7 @@ fn draw(
                 Span::styled(format!(" {}", artist_str), Style::default().fg(Color::Cyan)),
                 Span::styled(
                     format!(" {:>2}:{:02}", mins, secs),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(Color::Reset),
                 ),
                 Span::styled(
                     format!(
@@ -977,7 +977,7 @@ fn draw(
         .block(Block::default().borders(Borders::ALL).title(list_title))
         .highlight_style(
             Style::default()
-                .bg(Color::DarkGray)
+                .add_modifier(Modifier::REVERSED)
                 .add_modifier(Modifier::BOLD),
         );
 
@@ -1043,7 +1043,7 @@ fn draw(
             Some(ratio),
         )
     } else {
-        (" ■  No track selected".to_string(), Color::DarkGray, None)
+        (" ■  No track selected".to_string(), Color::Reset, None)
     };
 
     f.render_widget(
@@ -1054,11 +1054,11 @@ fn draw(
     if let Some(ratio) = progress_ratio {
         let gauge_color = match state.player_state() {
             PlayerState::Playing => Color::Yellow,
-            PlayerState::Paused => Color::DarkGray,
-            PlayerState::Stopped => Color::DarkGray,
+            PlayerState::Paused => Color::Reset,
+            PlayerState::Stopped => Color::Reset,
         };
         let gauge = Gauge::default()
-            .gauge_style(Style::default().fg(gauge_color).bg(Color::Black))
+            .gauge_style(Style::default().fg(gauge_color).bg(Color::Reset))
             .ratio(ratio)
             .label("");
         f.render_widget(gauge, np_rows[1]);
@@ -1156,7 +1156,7 @@ fn draw_source_picker(f: &mut ratatui::Frame, entries: &[SourceEntry], selected:
         )
         .highlight_style(
             Style::default()
-                .bg(Color::DarkGray)
+                .add_modifier(Modifier::REVERSED)
                 .add_modifier(Modifier::BOLD),
         );
 
@@ -1178,7 +1178,7 @@ fn draw_name_input(f: &mut ratatui::Frame, name_input: &str) {
                 .title(" Save Playlist  [Enter] save  [Esc] cancel ")
                 .border_style(Style::default().fg(Color::Cyan)),
         )
-        .style(Style::default().fg(Color::White));
+        .style(Style::default().fg(Color::Reset));
 
     f.render_widget(widget, area);
 }
@@ -1319,7 +1319,7 @@ fn draw_help_overlay(f: &mut ratatui::Frame, scroll: u16) {
                 .title(" キーバインド一覧  [↑↓] スクロール  [任意のキー] 閉じる ")
                 .border_style(Style::default().fg(Color::Green)),
         )
-        .style(Style::default().fg(Color::White))
+        .style(Style::default().fg(Color::Reset))
         .scroll((scroll, 0));
 
     f.render_widget(widget, area);


### PR DESCRIPTION
## 概要

Warp 等のターミナルでライトテーマに切り替えた際に TUI の表示が見づらくなる問題を修正した。ダークテーマ前提でハードコードされていた色を、端末のデフォルト色に追従する `Color::Reset` と `Modifier::REVERSED` に置き換えた。

## 問題

全ての色が `Color::DarkGray` / `Color::Black` / `Color::White` でハードコードされており、ライトテーマでは以下の箇所が読めなくなっていた:

- ゲージ背景 (`Color::Black`) → 白背景に真っ黒な帯が表示される
- オーバーレイテキスト (`Color::White`) → 白背景に白文字で不可視
- リストの選択ハイライト (`Color::DarkGray` 背景) → 白背景で判別不能
- 再生時間・非アクティブテキスト (`Color::DarkGray`) → 白背景で消える

## 変更内容

| 変更前 | 変更後 | 対象 |
|---|---|---|
| `fg(Color::DarkGray)` | `fg(Color::Reset)` | トラック一覧の再生時間 |
| `.bg(Color::DarkGray) + BOLD` | `REVERSED + BOLD` | トラック一覧の選択ハイライト |
| `Color::DarkGray`（No track） | `Color::Reset` | Now Playing の非アクティブ状態 |
| `Color::DarkGray`（Paused/Stopped） | `Color::Reset` | ゲージの非アクティブ色 |
| `.bg(Color::Black)` | `.bg(Color::Reset)` | ゲージ背景 |
| `.bg(Color::DarkGray) + BOLD` | `REVERSED + BOLD` | SourcePicker の選択ハイライト |
| `fg(Color::White)` | `fg(Color::Reset)` | Name Input オーバーレイテキスト |
| `fg(Color::White)` | `fg(Color::Reset)` | Help オーバーレイテキスト |

`Color::Green` / `Color::Cyan` / `Color::Yellow` 等の ANSI 16色はターミナルがテーマに合わせて自動調整するため変更しない。

## 動作

- `Color::Reset` — 端末のデフォルト前景色・背景色を使用。Warp に限らず全ターミナルで機能する
- `Modifier::REVERSED` — 前景色と背景色を入れ替え。ダーク・ライト両テーマで常に高コントラストなハイライトになる